### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Install
     如果你正在使用Ubuntu 10.10 (Maverick) 以上的版本，opencc已經被加入到了官方源中，使用
 
         sudo apt-get install opencc
+        sudo apt-get install libopencc-dev
 
     如果你更願意體驗最新的版本，請使用ppa：
 
         sudo add-apt-repository ppa:byvoid-kcp/ppa
         sudo apt-get update
         sudo apt-get install opencc
+        sudo apt-get install libopencc-dev
 
 
     Mac OS X

--- a/lib/ropencc.rb
+++ b/lib/ropencc.rb
@@ -3,8 +3,6 @@
 require 'ffi'
 
 class Ropencc
-    VERSION = '0.0.5'
-
     module LibOpenCC
         extend FFI::Library
         ffi_lib 'opencc'

--- a/lib/ropencc/version.rb
+++ b/lib/ropencc/version.rb
@@ -1,0 +1,3 @@
+class Ropencc
+    VERSION = '0.0.5'
+end

--- a/ropencc.gemspec
+++ b/ropencc.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/ropencc.rb', __FILE__)
+require File.expand_path('../lib/ropencc/version', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Psi"]


### PR DESCRIPTION
註明ubuntu上需要安裝libopencc-dev，才有 ffi 所需要的 libeopencc-dev.so 檔案。
把 version 分開，只需要版本資訊時就不用把整個 gem 讀進來。
